### PR TITLE
Further specified 'Script too long' error messages

### DIFF
--- a/lib/bfp.js
+++ b/lib/bfp.js
@@ -490,7 +490,7 @@ class Bfp {
         let encodedScript = utils.encodeScript(script);
 
         if (encodedScript.length > 223) {
-            throw Error("Script too long, must be less than 223 bytes.")
+            throw Error(`Metadata script too long, must be less than 223 bytes, but is ${encodedScript.length} bytes.`);
         }
 
         return encodedScript;
@@ -513,7 +513,7 @@ class Bfp {
 
         let encodedScript = utils.encodeScript(script);
         if (encodedScript.length > 223) {
-            throw Error("Script too long, must be less than 223 bytes.");
+            throw Error(`Data chunk script too long, must be less than 223 bytes, but is ${encodedScript.length} bytes.`);
         }
         return encodedScript;
     }


### PR DESCRIPTION
We were getting one of these error messages for some posts on Honest.cash, so I tracked it down to the metadata op_return being too big (large filename + uri :sweat_smile:). I feel like these changes clarify the error messages a bit more. Let me know what you think :smile: