### PR TITLE
0x02 Larger files

### DIFF
--- a/lib/bfp.d.ts
+++ b/lib/bfp.d.ts
@@ -44,19 +44,19 @@ export declare class Bfp {
     uploadHashOnlyObject(type: number, fundingUtxo: utxo, fundingAddress: string, fundingWif: string, objectDataArrayBuffer: Buffer, objectName?: string, objectExt?: string, prevObjectSha256Hex?: string, objectExternalUri?: string, objectReceiverAddress?: string, signProgressCallback?: Function, signFinishedCallback?: Function, uploadProgressCallback?: Function, uploadFinishedCallback?: Function): Promise<string>;
     uploadFolderHashOnly(fundingUtxo: utxo, fundingAddress: string, fundingWif: string, folderDataArrayBuffer: Buffer, folderName?: string, folderExt?: string, prevFolderSha256Hex?: string, folderExternalUri?: string, folderReceiverAddress?: string, signProgressCallback?: Function, signFinishedCallback?: Function, uploadProgressCallback?: Function, uploadFinishedCallback?: Function): Promise<string>;
     uploadFileHashOnly(fundingUtxo: utxo, fundingAddress: string, fundingWif: string, fileDataArrayBuffer: Buffer, fileName?: string, fileExt?: string, prevFileSha256Hex?: string, fileExternalUri?: string, fileReceiverAddress?: string, signProgressCallback?: Function, signFinishedCallback?: Function, uploadProgressCallback?: Function, uploadFinishedCallback?: Function): Promise<string>;
-    uploadFile(fundingUtxo: utxo, fundingAddress: string, fundingWif: string, fileDataArrayBuffer: Buffer, fileName?: string, fileExt?: string, prevFileSha256Hex?: string, fileExternalUri?: string, fileReceiverAddress?: string, signProgressCallback?: Function, signFinishedCallback?: Function, uploadProgressCallback?: Function, uploadFinishedCallback?: Function, delay_ms?: number): Promise<string>;
+    uploadFile(fundingUtxo: utxo, fundingAddress: string, fundingWif: string, fileDataArrayBuffer: Buffer, fileName?: string, fileExt?: string, prevFileSha256Hex?: string, fileExternalUri?: string, fileReceiverAddress?: string, signProgressCallback?: Function, signFinishedCallback?: Function, uploadProgressCallback?: Function, uploadFinishedCallback?: Function, delay_ms?: number, uploadMethod?: number): Promise<string>;
     downloadFile(bfpUri: string, progressCallback?: Function): Promise<{
         passesHashCheck: boolean;
         fileBuf: Buffer;
     }>;
-    static buildMetadataOpReturn(config: FileMetadata): Buffer;
-    static buildDataChunkOpReturn(chunkData: Buffer): Buffer;
+    private static buildMetadataOpReturn;
     buildFundingTx(config: FundingTxnConfig): Transaction;
-    buildChunkTx(config: DataChunkTxnConfig): Transaction;
-    buildMetadataTx(config: MetadataTxnConfig): Transaction;
-    calculateMetadataMinerFee(genesisOpReturnLength: number, feeRate?: number): number;
-    calculateDataChunkMinerFee(sendOpReturnLength: number, feeRate?: number): number;
-    static calculateFileUploadCost(fileSizeBytes: number, configMetadataOpReturn: FileMetadata, fee_rate?: number): number;
-    static chunk_can_fit_in_final_opreturn(script_length: number, chunk_data_length: number): boolean;
-    parsebfpDataOpReturn(hex: string): any;
+    private buildMetadataTx;
+    private calculateMetadataMinerFee;
+    static calculateFileUploadCost(fileSizeBytes: number, configMetadataOpReturn: FileMetadata, fee_rate?: number, uploadMethod?: number): number;
+    private static chunk_can_fit_in_final_opreturn;
+    private parsebfpDataOpReturn;
+    private parsebfpDataInput;
+    private static arrangeOutputs;
+    uploadTransactions(transactions: Transaction[], delay_ms: number, uploadProgressCallback?: Function): Promise<string>;
 }

--- a/lib/bfp.ts
+++ b/lib/bfp.ts
@@ -277,7 +277,8 @@ export class Bfp {
 
             let lastPushSize = pushSize - padDifference;
             // We forced at least 2 P2SH outputs of the last transaction already
-            if (capacity >= lastPushSize) {
+            // unless the file was too small (the second condition)
+            if ((capacity >= lastPushSize) && !(padDifference > pushSize)) {
                 // add data to metadata push
                 let configMetaOpReturn: FileMetadata = {
                     msgType: 2,
@@ -546,7 +547,7 @@ export class Bfp {
         script.push(config.msgType);
 
         // Chunk Count
-        let chunkCount = Utils.int2FixedBuffer(config.chunkCount, 1)
+        let chunkCount = Utils.int2FixedBuffer(config.chunkCount, 4);
         script = script.concat(Utils.getPushDataOpcode(chunkCount))
         chunkCount.forEach((item) => script.push(item))
 
@@ -568,7 +569,7 @@ export class Bfp {
             fileExt.forEach((item) => script.push(item));
         }
 
-        let fileSize = Utils.int2FixedBuffer(config.fileSize, 2)
+        let fileSize = Utils.int2FixedBuffer(config.fileSize, 8);
         script = script.concat(Utils.getPushDataOpcode(fileSize))
         fileSize.forEach((item) => script.push(item))
 

--- a/lib/bfp.ts
+++ b/lib/bfp.ts
@@ -1,4 +1,4 @@
-import { Address, Script, Transaction } from "bitcore-lib-cash";
+import { Address, Script, Transaction, PrivateKey } from "bitcore-lib-cash";
 import { Utils } from './utils';
 import { IGrpcClient } from 'grpc-bchrpc';
 
@@ -69,7 +69,7 @@ export class Bfp {
         signProgressCallback?: Function,
         signFinishedCallback?: Function,
         uploadProgressCallback?: Function,
-        uploadFinishedCallback?: Function) {
+        uploadFinishedCallback?: Function): Promise<string> {
         let fileSize = objectDataArrayBuffer.byteLength;
         let hash = Utils.Hash256(objectDataArrayBuffer).toString('hex');
 
@@ -166,7 +166,7 @@ export class Bfp {
         signProgressCallback?: Function,
         signFinishedCallback?: Function,
         uploadProgressCallback?: Function,
-        uploadFinishedCallback?: Function) {
+        uploadFinishedCallback?: Function): Promise<string> {
         return await this.uploadHashOnlyObject(3,
             fundingUtxo,
             fundingAddress,
@@ -197,7 +197,7 @@ export class Bfp {
         signProgressCallback?: Function,
         signFinishedCallback?: Function,
         uploadProgressCallback?: Function,
-        uploadFinishedCallback?: Function) {
+        uploadFinishedCallback?: Function): Promise<string> {
         return await this.uploadHashOnlyObject(1,
             fundingUtxo,
             fundingAddress,
@@ -229,30 +229,30 @@ export class Bfp {
         signFinishedCallback?: Function,
         uploadProgressCallback?: Function,
         uploadFinishedCallback?: Function,
-        delay_ms = 500) {
+        delay_ms = 500,
+        uploadMethod = 0): Promise<string> {
 
         let fileSize = fileDataArrayBuffer.byteLength;
         let hash = Utils.Sha256(fileDataArrayBuffer).toString('hex');
 
-        // chunks
-        let chunks = [];
-        let chunkCount = Math.floor(fileSize / 220);
-
-        for (let nId = 0; nId < chunkCount; nId++) {
-            chunks.push(fileDataArrayBuffer.slice(nId * 220, (nId + 1) * 220));
+        // P2SH outputs per transaction
+        let perTransactionCapacity = 0;
+        let msgType = 0x01;
+        if (uploadMethod == 1) {
+            perTransactionCapacity = 50;
+            msgType = 0x02;
         }
 
-        // meta
-        if (fileSize % 220) {
-            chunks[chunkCount] = fileDataArrayBuffer.slice(chunkCount * 220, fileSize);
-            chunkCount++;
-        }
+        const perInputCapacity = 1497;
+        let arrangement = Bfp.arrangeOutputs(fileSize, perTransactionCapacity);
+        let conservativeFileSize = arrangement.conservativeFileSize;
+        let numberOfOuts = arrangement.numberOfOuts;
+        let transactionCount = numberOfOuts.length;
 
-        // estimate cost
-        // build empty meta data OpReturn
+        // Build the last OP_RETURN push first
         let configEmptyMetaOpReturn: FileMetadata = {
-            msgType: 1,
-            chunkCount: chunkCount,
+            msgType: msgType,
+            chunkCount: transactionCount,
             fileName: fileName,
             fileExt: fileExt,
             fileSize: fileSize,
@@ -260,101 +260,162 @@ export class Bfp {
             prevFileSha256Hex: prevFileSha256Hex,
             fileUri: fileExternalUri
         };
+        let finalOpReturn = Bfp.buildMetadataOpReturn(configEmptyMetaOpReturn);
+
+        const padDifference = conservativeFileSize - fileSize;
+        let buf = fileDataArrayBuffer;
+        if (padDifference != 0) {
+            if (padDifference < 0) {
+                console.log("Negative padding!")
+            }
+
+            // Handle the case that padding is not needed and last bytes fit into metadata push
+            let capacity = 223 - finalOpReturn.length;
+            let pushSize = 220;
+            if (uploadMethod == 1) {
+                pushSize = perInputCapacity;
+            }
+
+            let lastPushSize = pushSize - padDifference;
+            // We forced at least 2 P2SH outputs of the last transaction already
+            if (capacity >= lastPushSize) {
+                // add data to metadata push
+                let configMetaOpReturn: FileMetadata = {
+                    msgType: 2,
+                    // Now, the last tx has a data-containing OP_RETURN too
+                    chunkCount: transactionCount + 1,
+                    fileName: fileName,
+                    fileExt: fileExt,
+                    fileSize: fileSize,
+                    fileSha256Hex: hash,
+                    prevFileSha256Hex: prevFileSha256Hex,
+                    fileUri: fileExternalUri,
+                    chunkData: buf.slice(-lastPushSize)
+                };
+                finalOpReturn = Bfp.buildMetadataOpReturn(configMetaOpReturn);
+                if (uploadMethod == 1) {
+                    // So a padded P2SH push is not needed
+                    numberOfOuts[transactionCount - 1]--;
+                } else {
+                    // One padded OP_RETURN push is not needed
+                    transactionCount--;
+                }
+                // We already handled the last padDifference
+                buf = buf.slice(0, -lastPushSize);
+                conservativeFileSize -= lastPushSize;
+            } else {
+                buf = Buffer.alloc(conservativeFileSize);
+                buf.set(fileDataArrayBuffer);
+            }
+        }
+
+        const privateKey = PrivateKey.fromWIF(fundingWif);
+        const publicKey = privateKey.toPublicKey();
+        let publicKeyAsBuffer = publicKey.toBuffer();
+        let bufferHex = publicKeyAsBuffer.toString('hex');
+        publicKeyAsBuffer.toString = function() {
+            return bufferHex;
+        }
+        const address = Address.fromString(fundingAddress);
+
+        let receiver;
+        if (fileReceiverAddress) {
+            receiver = Address.fromString(fileReceiverAddress);
+        } else {
+            receiver = address;
+        }
 
         //* ** building transaction
-        let transactions = [];
+        let transactions: Transaction[] = [];
+        let fileIndex = 0, tx = new Transaction().feePerByte(this.FEE_RATE);
 
         // show progress
-        let nDiff = 100 / chunkCount;
+        let nDiff = 100 / transactionCount;
         let nCurPos = 0;
 
-        for (let nId = 0; nId < chunkCount; nId++) {
-            // build chunk data OpReturn
-            let chunkOpReturn = Bfp.buildDataChunkOpReturn(chunks[nId]);
+        tx.addInput(
+            new Transaction.Input.PublicKeyHash({
+                output: new Transaction.Output({
+                    script: Script.buildPublicKeyHashOut(address),
+                    satoshis: fundingUtxo.satoshis
+                }),
+                prevTxId: fundingUtxo.txid,
+                outputIndex: fundingUtxo.vout,
+                script: Script.empty()
+            })
+        )
 
-            let txid = '';
-            let satoshis = 0;
-            let vout = 1;
-            if (nId === 0) {
-                txid = fundingUtxo.txid;
-                satoshis = fundingUtxo.satoshis;
-                vout = fundingUtxo.vout;
-            } else {
-                txid = transactions[nId - 1].id;
-                satoshis = transactions[nId - 1].outputs[1].satoshis;
+        for (let nId = 0; nId < transactionCount; nId++) {
+            tx = tx.addData(
+                buf.slice(fileIndex, fileIndex + 220)
+            );
+            fileIndex += 220;
+
+            const outsInThisTX = numberOfOuts[nId];
+            var txStartIndex = fileIndex;
+
+            for (let z = 0; z < outsInThisTX; z++) {
+                tx = tx.addOutput(
+                    new Transaction.Output({
+                        script:
+                            Script.buildScriptHashOut(
+                                (Script as any).buildPushOut(
+                                    [publicKeyAsBuffer], [buf.slice(fileIndex, fileIndex + 1013), buf.slice(fileIndex + 1013, fileIndex + 1497)]
+                                )
+                            ),
+                        satoshis:
+                            546
+                    })
+                );
+                fileIndex += 1497;
             }
 
-            // build chunk data transaction
-            let configChunkTx: DataChunkTxnConfig = {
-                bfpChunkOpReturn: chunkOpReturn,
-                input_utxo: <utxo>{
-                    address: fundingAddress,
-                    txid: txid,
-                    vout: vout,
-                    satoshis: satoshis,
-                    wif: fundingWif
-                }
-            };
+            (tx as any)._changeScript = Script.buildPublicKeyOut(publicKey);
+            (tx as any)._clearSignatures = function() { };
+            (tx as any)._updateChangeOutput();
 
-            let chunksTx = this.buildChunkTx(configChunkTx);
-
-            if (nId === chunkCount - 1) {
-                let emptyOpReturn = Bfp.buildMetadataOpReturn(configEmptyMetaOpReturn);
-                let capacity = 223 - emptyOpReturn.length;
-                if (capacity >= chunks[nId].byteLength) {
-                    // finish with just a single metadata txn
-                    // build meta data OpReturn
-                    let configMetaOpReturn = {
-                        msgType: 1,
-                        chunkCount: chunkCount,
-                        fileName: fileName,
-                        fileExt: fileExt,
-                        fileSize: fileSize,
-                        fileSha256Hex: hash,
-                        prevFileSha256Hex: prevFileSha256Hex,
-                        fileUri: fileExternalUri,
-                        chunkData: chunks[nId]
-                    };
-                    let metaOpReturn = Bfp.buildMetadataOpReturn(configMetaOpReturn);
-
-                    // build meta data transaction
-                    let configMetaTx = {
-                        bfpMetadataOpReturn: metaOpReturn,
-                        input_utxo: {
-                            txid: txid,
-                            vout: vout,
-                            satoshis: satoshis,
-                            wif: fundingWif,
-                            address: fundingAddress
-                        },
-                        fileReceiverAddress: fileReceiverAddress != null ? fileReceiverAddress : fundingAddress
-                    };
-                    let metaTx = this.buildMetadataTx(configMetaTx);
-                    transactions.push(metaTx);
-                } else {
-                    // finish with both chunk txn and then final empty metadata txn
-                    transactions.push(chunksTx);
-
-                    let metaOpReturn = Bfp.buildMetadataOpReturn(configEmptyMetaOpReturn);
-
-                    // build meta data transaction
-                    let configMetaTx = {
-                        bfpMetadataOpReturn: metaOpReturn,
-                        input_utxo: {
-                            txid: chunksTx.id,
-                            vout: vout,
-                            satoshis: chunksTx.outputs[1].satoshis,
-                            wif: fundingWif,
-                            address: fundingAddress
-                        },
-                        fileReceiverAddress: fileReceiverAddress != null ? fileReceiverAddress : fundingAddress
-                    };
-                    let metaTx = this.buildMetadataTx(configMetaTx);
-                    transactions.push(metaTx);
-                }
-            } else { // not last transaction
-                transactions.push(chunksTx);
+            if (uploadMethod == 1) {
+                // Set change
+                const changeIndex = (tx as any)._changeIndex;
+                if (!changeIndex) console.log("Not enough funds!")
+                const changeOutput = tx.outputs[changeIndex];
+                const totalOutputAmount = (tx as any)._outputAmount;
+                (tx as any)._removeOutput(changeIndex);
+                (tx as any)._outputAmount = totalOutputAmount;
+                (tx.outputs[1] as any).satoshis += changeOutput.satoshis;
             }
+
+            tx = tx.sign(privateKey);
+            transactions.push(tx);
+
+            const txHash = tx.hash;
+
+            let tx2 = new Transaction().feePerByte(this.FEE_RATE);
+
+            if (outsInThisTX == 0) {
+                tx2 = (tx2 as any).from({
+                    "txid": txHash,
+                    "vout": 1,
+                    "address": address,
+                    "scriptPubKey": tx.outputs[1].script,
+                    "satoshis": tx.outputs[1].satoshis
+                });
+            }
+            for (let i = 1; i <= outsInThisTX; i++) {
+                tx2 = (tx2 as any).from({
+                    "txid": txHash,
+                    "vout": i,
+                    "address": address,
+                    "scriptPubKey": tx.outputs[i].script,
+                    "satoshis": tx.outputs[i].satoshis
+                },
+                    [publicKeyAsBuffer], 1, [
+                        buf.slice(txStartIndex, txStartIndex + 1013),
+                        buf.slice(txStartIndex + 1013, txStartIndex + 1497)
+                    ]);
+                txStartIndex += 1497;
+            }
+            tx = tx2;
 
             // sign progress
             if (signProgressCallback != null) {
@@ -363,55 +424,25 @@ export class Bfp {
             nCurPos += nDiff;
         }
 
+        if (fileIndex != buf.length) {
+            console.log("Padding error " + fileIndex + " " + buf.length)
+        }
+
+        tx.addOutput(new Transaction.Output({
+            script: finalOpReturn,
+            satoshis: 0
+        }));
+
+        const lastTx = tx.change(receiver);
+        if (!(lastTx as any)._changeIndex) console.log("Not enough funds for the last transaction!")
+        transactions.push(lastTx.sign(privateKey));
+
         // progress : signing finished
         if (signFinishedCallback != null) {
             signFinishedCallback();
         }
 
-        //* ** sending transaction
-        nDiff = 100 / transactions.length;
-        nCurPos = 0;
-        if (uploadProgressCallback != null) {
-            uploadProgressCallback(0);
-        }
-        let bfTxId: string;
-        for (let nId = 0; nId < transactions.length; nId++) {
-            console.log('transaction: ', transactions[nId].id);
-
-            while (true) {
-                console.log(`upload progress: ${nCurPos}%`);
-                try {
-                    let txnHex = transactions[nId].uncheckedSerialize();
-                    const res = await this.client.submitTransaction({ txnHex });
-                    bfTxId = Buffer.from(res.getHash_asU8().reverse()).toString("hex");
-                    break;
-                } catch (err) {
-                    if (err.message.includes("fully-spent transaction")) {
-                        console.log(`skipping transaction already spent ${transactions[nId].id}`);
-                        break;
-                    } else if (err.message.includes("transaction already exists")) {
-                        console.log(`transaction already exists ${transactions[nId].id}`);
-                        break;
-                    } else if (err.message.includes("already have transaction")) {
-                        console.log(`already have transaction ${transactions[nId].id}`);
-                        break;
-                    } else {
-                        console.log(`waiting 60 sec to try again: ${err}`);
-                        await sleep(60000);
-                    }
-                }
-            }
-            // progress
-            if (uploadProgressCallback != null) {
-                uploadProgressCallback(nCurPos);
-            }
-            nCurPos += nDiff;
-
-            // delay between transactions
-            await sleep(delay_ms);
-        }
-
-        bfTxId = 'bitcoinfile:' + bfTxId!;
+        let bfTxId = await this.uploadTransactions(transactions, delay_ms, uploadProgressCallback);
         if (uploadFinishedCallback != null) {
             uploadFinishedCallback(bfTxId);
         }
@@ -436,12 +467,15 @@ export class Bfp {
         let bfpMsg = <any>this.parsebfpDataOpReturn(metadata_opreturn_hex);
 
         let downloadCount = bfpMsg.chunk_count;
-        if (bfpMsg.chunk_count > 0 && bfpMsg.chunk != null && bfpMsg.chunk.length > 0) {
-            downloadCount = bfpMsg.chunk_count - 1;
+        if (downloadCount > 0 && bfpMsg.chunk != null && bfpMsg.chunk.length > 0) {
+            downloadCount--;
             chunks.push(bfpMsg.chunk)
             size += <number>bfpMsg.chunk.length;
         }
 
+        let inputData = <any>this.parsebfpDataInput(tx.getTransaction()!.getInputsList());
+        chunks.push(inputData);
+        size += <number>inputData.length;
 
         // Loop through raw transactions, parse out data
         for (let index = 0; index < downloadCount; index++) {
@@ -456,9 +490,21 @@ export class Bfp {
             chunks.push(bfpMsg.chunk);
             size += <number>bfpMsg.chunk.length;
 
+            // parse vin for data
+            let inputData = <any>this.parsebfpDataInput(tx.getTransaction()!.getInputsList());
+            chunks.push(inputData);
+            size += <number>inputData.length;
+
             if (progressCallback) {
                 progressCallback(index / (downloadCount - 1));
             }
+        }
+
+        if (bfpMsg.filesize) {
+            if (size < bfpMsg.filesize) {
+                console.log("Bad length, read too little!");
+            }
+            size = bfpMsg.filesize;
         }
 
         // reverse order of chunks
@@ -638,42 +684,6 @@ export class Bfp {
         return tx;
     }
 
-    buildChunkTx(config: DataChunkTxnConfig) {
-
-        let tx = new Transaction();
-        tx.feePerByte(this.FEE_RATE);
-
-        tx.addInput(new Transaction.Input.PublicKeyHash({
-            output: new Transaction.Output({
-                script: Script.buildPublicKeyHashOut(new Address(config.input_utxo.address!)),
-                satoshis: config.input_utxo.satoshis
-            }),
-            prevTxId: Buffer.from(config.input_utxo.txid, "hex"),
-            outputIndex: config.input_utxo.vout,
-            script: Script.empty()
-        }));
-
-        let chunkTxFee = this.calculateDataChunkMinerFee(config.bfpChunkOpReturn.length);
-        let outputAmount = config.input_utxo.satoshis - chunkTxFee;
-
-        // Chunk OpReturn
-        tx.addOutput(new Transaction.Output({
-            script: config.bfpChunkOpReturn,
-            satoshis: 0
-        }));
-
-        // Genesis token mint
-        tx.addOutput(new Transaction.Output({
-            script: new Script(new Address(config.input_utxo.address!)),
-            satoshis: outputAmount
-        }));
-
-        // sign inputs
-        tx.sign(config.input_utxo.wif!);
-
-        return tx;
-    }
-
     buildMetadataTx(config: MetadataTxnConfig) {
 
         let tx = new Transaction();
@@ -722,45 +732,67 @@ export class Bfp {
         return fee
     }
 
-    calculateDataChunkMinerFee(sendOpReturnLength: number, feeRate = 1) {
-        let fee = 195; // 1 p2pkh and 1 p2pkh output ~195 bytes
-        fee += sendOpReturnLength
-        fee += 10 // added to account for OP_RETURN ammount of 0000000000000000
-        fee *= feeRate
-        return fee
-    }
+    static calculateFileUploadCost(
+        fileSizeBytes: number,
+        configMetadataOpReturn: FileMetadata,
+        fee_rate = 1,
+        uploadMethod = 0) {
+        let byte_count = 0;
+        if (uploadMethod == 1) {
+            let arrangement = Bfp.arrangeOutputs(fileSizeBytes, 50);
+            let numberOfOuts = arrangement.numberOfOuts;
+            let transactionCount = numberOfOuts.length;
 
-    static calculateFileUploadCost(fileSizeBytes: number, configMetadataOpReturn: FileMetadata, fee_rate = 1) {
-        let byte_count = fileSizeBytes;
-        let whole_chunks_count = Math.floor(fileSizeBytes / 220);
-        let last_chunk_size = fileSizeBytes % 220;
+            const costConstantSizeWithOPReturn = 258;
+            const costP2SHOut = 32;
+            const costP2SHIn = 1689;
+            const costP2PKHIn = 144;
+            const costP2PKHOut = 35;
 
-        // cost of final transaction's op_return w/o any chunkdata
-        let final_op_return_no_chunk = Bfp.buildMetadataOpReturn(configMetadataOpReturn);
-        byte_count += final_op_return_no_chunk.length;
+            // First transaction
+            let byteCount = costP2PKHIn + costConstantSizeWithOPReturn;
 
-        // cost of final transaction's input/outputs
-        byte_count += 35;
-        byte_count += 148 + 1;
+            for (let i = 1; i < transactionCount; i++ , byteCount += costConstantSizeWithOPReturn) {
+                byteCount += costP2SHIn * numberOfOuts[i - 1] + costP2SHOut * numberOfOuts[i];
+            }
 
-        // cost of chunk trasnsaction op_returns
-        byte_count += (whole_chunks_count + 1) * 3;
+            // Last transaction
+            // transactionCount counts only P2SH-forming transactions
+            byte_count += costConstantSizeWithOPReturn
+                + numberOfOuts[transactionCount - 1] * costP2SHIn
+                + costP2PKHOut;
+        } else {
+            byte_count = fileSizeBytes;
+            let whole_chunks_count = Math.floor(fileSizeBytes / 220);
+            let last_chunk_size = fileSizeBytes % 220;
 
-        if (!Bfp.chunk_can_fit_in_final_opreturn(final_op_return_no_chunk.length, last_chunk_size)) {
-            // add fees for an extra chunk transaction input/output
-            byte_count += 149 + 35;
-            // opcode cost for chunk op_return
-            byte_count += 16;
+            // cost of final transaction's op_return w/o any chunkdata
+            let final_op_return_no_chunk = Bfp.buildMetadataOpReturn(configMetadataOpReturn);
+            byte_count += final_op_return_no_chunk.length;
+
+            // cost of final transaction's input/outputs
+            byte_count += 35;
+            byte_count += 148 + 1;
+
+            // cost of chunk trasnsaction op_returns
+            byte_count += (whole_chunks_count + 1) * 3;
+
+            if (!Bfp.chunk_can_fit_in_final_opreturn(final_op_return_no_chunk.length, last_chunk_size)) {
+                // add fees for an extra chunk transaction input/output
+                byte_count += 149 + 35;
+                // opcode cost for chunk op_return
+                byte_count += 16;
+            }
+
+            // output p2pkh
+            byte_count += 35 * (whole_chunks_count);
+
+            // dust input bytes (this is the initial payment for the file upload)
+            byte_count += (148 + 1) * whole_chunks_count;
+
+            // other unaccounted per txn
+            byte_count += 22 * (whole_chunks_count + 1);
         }
-
-        // output p2pkh
-        byte_count += 35 * (whole_chunks_count);
-
-        // dust input bytes (this is the initial payment for the file upload)
-        byte_count += (148 + 1) * whole_chunks_count;
-
-        // other unaccounted per txn
-        byte_count += 22 * (whole_chunks_count + 1);
 
         // dust output to be passed along each txn
         let dust_amount = 546;
@@ -810,8 +842,8 @@ export class Bfp {
         }
 
         // 01 = On-chain File
-        if ((script[2] != 'OP_1') && (script[2] != '01')) {
-            throw new Error('Not a BFP file (type 0x01)');
+        if ((script[2] != 'OP_1') && (script[2] != '01') && (script[2] != 'OP_2') && (script[2] != '02')) {
+            throw new Error('Not a BFP file (type 0x01 or 0x02)');
         }
 
         // chunk count
@@ -875,5 +907,157 @@ export class Bfp {
         }
 
         return bfpData;
+    }
+
+    parsebfpDataInput(inputList: any) {
+        let chunks = [];
+        let len = 0;
+        const inputListLen = inputList.length;
+        for (let i = 0; i < inputListLen; i++) {
+            let hex = Buffer.from(inputList[i].getSignatureScript_asU8()).toString('hex')
+
+            // Normal P2PKH input
+            if (hex.length < 220) {
+                return Buffer.allocUnsafe(0);
+            }
+
+            const script = Script.fromHex(hex).toASM().split(" ");
+
+            let buf = Buffer.from(script[2], 'hex')
+            chunks.push(buf);
+            len += buf.length;
+
+            buf = Buffer.from(script[3], 'hex')
+            chunks.push(buf);
+            len += buf.length;
+
+            const innerScript = Script.fromHex(script[4]).toASM().split(" ");
+
+            buf = Buffer.from(innerScript[9], 'hex')
+            chunks.push(buf);
+            len += buf.length;
+        }
+
+        let fileBuf = Buffer.alloc(len);
+        let index = 0;
+        chunks.forEach(chunk => {
+            chunk.copy(fileBuf, index)
+            index += chunk.length;
+        });
+        return fileBuf;
+    }
+
+    static arrangeOutputs(fileSize: number, perTransactionCapacity: number) {
+        const perInputCapacity = 1497
+        // Maximum inputs per tx: 50
+        const totalPerTransactionCapacity = perTransactionCapacity * perInputCapacity + 220;
+        let transactionCount = Math.ceil(fileSize / totalPerTransactionCapacity);
+        // Doesn't include the last transaction, which creates no P2SH outputs
+        let numberOfOuts = new Uint8Array(transactionCount);
+        // waterfill
+        numberOfOuts.fill(perTransactionCapacity);
+
+        if (perTransactionCapacity == 0) {
+            // There's no concept of "Outs"
+            // Add padding and calculate the conservative file size with padding
+            let conservativeFileSize = transactionCount * 220;
+            return { conservativeFileSize, numberOfOuts }
+        }
+
+        // calculate the number of outs of last tx
+        const leftOver = (fileSize - (transactionCount - 1) * totalPerTransactionCapacity - 220)
+        numberOfOuts[transactionCount - 1] = Math.ceil(leftOver / perInputCapacity)
+
+        // These may bypass the limit "Maximum inputs per tx: 50"
+        // up to 52, which is safe.
+        if (transactionCount > 1) {
+            // Move one push to the last transaction
+            // This removes the need to waste more space in the
+            // "numberOfOuts[transactionCount - 1] == 0" conditional later
+            if (numberOfOuts[transactionCount - 2] > 1) {
+                numberOfOuts[transactionCount - 2]--;
+                numberOfOuts[transactionCount - 1]++;
+            }
+
+            // Move another push to the last transaction
+            // This may allow us to possibly save space
+            // by moving extra data to the metadata OP_RETURN push
+            // instead of padding to fill one P2SH push
+            // by guaranteeing that there would still be one P2SH push
+            if (numberOfOuts[transactionCount - 2] > 1) {
+                numberOfOuts[transactionCount - 2]--;
+                numberOfOuts[transactionCount - 1]++;
+            } else if ((transactionCount > 2)
+                && (numberOfOuts[transactionCount - 3] > 1)) {
+                // This branch may run only if "Maximum inputs per tx"
+                // is reduced to 1
+                numberOfOuts[transactionCount - 3]--;
+                numberOfOuts[transactionCount - 1]++;
+            }
+        }
+
+        // Transactions are linked by P2SH outputs, so one is needed every time.
+        // This condition is true if the file is little
+        if (numberOfOuts[transactionCount - 1] == 0) {
+            // will be padded later
+            numberOfOuts[transactionCount - 1]++
+        }
+
+        // Add padding and calculate the conservative file size with padding
+        let conservativeFileSize = 0;
+        for (let i = 0; i < transactionCount; i++ , conservativeFileSize += 220) {
+            conservativeFileSize += numberOfOuts[i] * perInputCapacity;
+        }
+
+        return { conservativeFileSize, numberOfOuts }
+    }
+
+    async uploadTransactions(
+        transactions: Transaction[],
+        delay_ms: number,
+        uploadProgressCallback?: Function): Promise<string> {
+        let nDiff = 100 / transactions.length;
+        let nCurPos = 0;
+        if (uploadProgressCallback != null) {
+            uploadProgressCallback(0);
+        }
+        let bfTxId: string;
+        for (let nId = 0; nId < transactions.length; nId++) {
+            console.log('transaction: ', transactions[nId].id);
+
+            while (true) {
+                console.log(`upload progress: ${nCurPos}%`);
+                try {
+                    let txnHex = transactions[nId].uncheckedSerialize();
+                    const res = await this.client.submitTransaction({ txnHex });
+                    bfTxId = Buffer.from(res.getHash_asU8().reverse()).toString("hex");
+                    break;
+                } catch (err) {
+                    if (err.message.includes("fully-spent transaction")) {
+                        console.log(`skipping transaction already spent ${transactions[nId].id}`);
+                        break;
+                    } else if (err.message.includes("transaction already exists")) {
+                        console.log(`transaction already exists ${transactions[nId].id}`);
+                        break;
+                    } else if (err.message.includes("already have transaction")) {
+                        console.log(`already have transaction ${transactions[nId].id}`);
+                        break;
+                    } else {
+                        console.log(`waiting 60 sec to try again: ${err}`);
+                        await sleep(60000);
+                    }
+                }
+            }
+            // progress
+            if (uploadProgressCallback != null) {
+                uploadProgressCallback(nCurPos);
+            }
+            nCurPos += nDiff;
+
+            // delay between transactions
+            await sleep(delay_ms);
+        }
+
+        return 'bitcoinfile:' + bfTxId!;
     }
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -35,7 +35,8 @@ export class Utils {
 
     static int2FixedBuffer(amount: number, size: number) {
         let hex = amount.toString(16);
-        hex = hex.padStart(size * 2, '0');
+        // pad the beginning with '0' to length size * 2
+        hex = '0'.repeat(size * 2 - hex.length) + hex;
         if (hex.length % 2) hex = '0' + hex;
         return Buffer.from(hex, 'hex');
     }

--- a/patches/bitcore-lib-cash+8.25.7.patch
+++ b/patches/bitcore-lib-cash+8.25.7.patch
@@ -13,3 +13,142 @@ index a562c53..eaa3746 100644
  
  // crypto
  bitcore.crypto = {};
+diff --git a/node_modules/bitcore-lib-cash/lib/script/script.js b/node_modules/bitcore-lib-cash/lib/script/script.js
+index 4a4ca80..14135c2 100644
+--- a/node_modules/bitcore-lib-cash/lib/script/script.js
++++ b/node_modules/bitcore-lib-cash/lib/script/script.js
+@@ -736,6 +736,36 @@ Script.buildMultisigOut = function(publicKeys, threshold, opts) {
+   return script;
+ };
+ 
++// TODO BitcoinFiles
++Script.buildPushOut = function(publicKeys, opts) {
++  opts = opts || {};
++  var script = new Script();
++  script.add(Opcode.OP_HASH160)
++    .add(Opcode.OP_SWAP)
++    .add(Opcode.OP_HASH160)
++    .add(Opcode.OP_CAT)
++    .add(Opcode.OP_2DUP)
++    .add(Opcode.OP_CAT)
++    .add(Opcode.OP_HASH160);
++  script.add(Hash.sha256ripemd160(Buffer.from(
++    Buffer.concat([publicKeys[0],
++      Hash.sha256ripemd160(
++        Buffer.from(opts[0].slice(520))
++      ),
++      Hash.sha256ripemd160(
++        Buffer.from(opts[0].slice(0,520))
++      )
++    ])
++  )));
++  script.add(Opcode.OP_EQUALVERIFY)
++    .add(Buffer.from(opts[1]))
++    .add(Opcode.OP_2DROP)
++    .add(Opcode.OP_CHECKSIGVERIFY)
++    .add(Opcode.OP_DEPTH)
++    .add(Opcode.OP_NOT);
++  return script;
++};
++
+ /**
+  * A new Multisig input script for the given public keys, requiring m of those public keys to spend
+  *
+@@ -861,6 +891,26 @@ Script.buildP2SHMultisigIn = function(pubkeys, threshold, signatures, opts) {
+   return s;
+ };
+ 
++// TODO BitcoinFiles
++Script.buildP2SHPushIn = function(pubkeys, opts, signatures) {
++  $.checkArgument(_.isArray(pubkeys));
++  $.checkArgument(_.isArray(opts));
++  $.checkArgument(_.isArray(signatures));
++  var s = new Script();
++  _.each(signatures, function(signature) {
++    $.checkArgument(BufferUtil.isBuffer(signature), 'Signatures must be an array of Buffers');
++    // TODO: allow signatures to be an array of Signature objects
++    s.add(signature);
++  });
++  s.add(pubkeys[0]);
++  s.add(Buffer.from(opts[0].slice(0, 520)));
++  s.add(Buffer.from(opts[0].slice(520)));
++  s.add(
++    Script.buildPushOut(pubkeys, opts).toBuffer()
++  );
++  return s;
++};
++
+ /**
+  * @returns {Script} a new pay to public key hash output for the given
+  * address or public key
+diff --git a/node_modules/bitcore-lib-cash/lib/transaction/input/multisigscripthash.js b/node_modules/bitcore-lib-cash/lib/transaction/input/multisigscripthash.js
+index 7d00787..599975a 100644
+--- a/node_modules/bitcore-lib-cash/lib/transaction/input/multisigscripthash.js
++++ b/node_modules/bitcore-lib-cash/lib/transaction/input/multisigscripthash.js
+@@ -16,6 +16,10 @@ var TransactionSignature = require('../signature');
+ /**
+  * @constructor
+  */
++// TODO BitcoinFiles
++// pubkeys = [pubkey]
++// threshold = 1
++// opts = [push up to 1013, push up to 484]
+ function MultiSigScriptHashInput(input, pubkeys, threshold, signatures, opts) {
+   /* jshint maxstatements:20 */
+   opts = opts || {};
+@@ -24,12 +28,10 @@ function MultiSigScriptHashInput(input, pubkeys, threshold, signatures, opts) {
+   pubkeys = pubkeys || input.publicKeys;
+   threshold = threshold || input.threshold;
+   signatures = signatures || input.signatures;
+-  if (opts.noSorting) {
+-    this.publicKeys = pubkeys
+-  } else  {
+-    this.publicKeys = _.sortBy(pubkeys, function(publicKey) { return publicKey.toString('hex'); });
+-  }
+-  this.redeemScript = Script.buildMultisigOut(this.publicKeys, threshold, opts);
++  // TODO BitcoinFiles
++  this.publicKeys = pubkeys
++  this.opts = opts
++  this.redeemScript = Script.buildPushOut(this.publicKeys, opts);
+   $.checkState(Script.buildScriptHashOut(this.redeemScript).equals(this.output.script),
+                'Provided public keys don\'t hash to the provided output');
+   this.publicKeyIndex = {};
+@@ -44,6 +46,8 @@ function MultiSigScriptHashInput(input, pubkeys, threshold, signatures, opts) {
+ inherits(MultiSigScriptHashInput, Input);
+ 
+ MultiSigScriptHashInput.prototype.toObject = function() {
++  // TODO BitcoinFiles
++  if (console) console.log("toObject unimplemented for P2SH data push inputs!");
+   var obj = Input.prototype.toObject.apply(this, arguments);
+   obj.threshold = this.threshold;
+   obj.publicKeys = _.map(this.publicKeys, function(publicKey) { return publicKey.toString(); });
+@@ -102,9 +106,9 @@ MultiSigScriptHashInput.prototype.addSignature = function(transaction, signature
+ };
+ 
+ MultiSigScriptHashInput.prototype._updateScript = function(signingMethod, checkBitsField) {
+-  this.setScript(Script.buildP2SHMultisigIn(
++  this.setScript(Script.buildP2SHPushIn(
+     this.publicKeys,
+-    this.threshold,
++    this.opts,
+     this._createSignatures(signingMethod),
+     { cachedMultisig: this.redeemScript, checkBits: checkBitsField, signingMethod }
+   ));
+@@ -165,14 +169,10 @@ MultiSigScriptHashInput.prototype.isValidSignature = function(transaction, signa
+   );
+ };
+ 
+-MultiSigScriptHashInput.OPCODES_SIZE = 7; // serialized size (<=3) + 0 .. N .. M OP_CHECKMULTISIG
+-MultiSigScriptHashInput.SIGNATURE_SIZE = 74; // size (1) + DER (<=72) + sighash (1)
+-MultiSigScriptHashInput.PUBKEY_SIZE = 34; // size (1) + DER (<=33)
+-
++// TODO BitcoinFiles
+ MultiSigScriptHashInput.prototype._estimateSize = function() {
+-  return MultiSigScriptHashInput.OPCODES_SIZE +
+-    this.threshold * MultiSigScriptHashInput.SIGNATURE_SIZE +
+-    this.publicKeys.length * MultiSigScriptHashInput.PUBKEY_SIZE;
++  return 33 + 3 + this.opts[0].length + 
++    74+34+3+3+this.opts[1].length+3;
+ };
+ 
+ module.exports = MultiSigScriptHashInput;

--- a/regtest/test/file_type_0x02.ts
+++ b/regtest/test/file_type_0x02.ts
@@ -146,7 +146,7 @@ describe("Bitcoin File type 0x02", () => {
     } as utxo;
 
     const cb = (inp: string) => { console.log(inp); }
-    fileID = await bfp.uploadFile(txo, wallet2.bchRegtestAddress, wallet2.wif, fileBuf, "mario", "png", undefined, undefined, wallet2.bchRegtestAddress, cb, cb, cb, cb, 0, 1);
+    fileID = await bfp.uploadFile(txo, wallet2.bchRegtestAddress, wallet2.wif, fileBuf, "mario", "png", undefined, undefined, wallet2.bchRegtestAddress, cb, cb, cb, cb, 0, 2);
   });
 
   step("Download an 0x02 file", async function() {

--- a/regtest/test/file_type_0x02.ts
+++ b/regtest/test/file_type_0x02.ts
@@ -1,0 +1,157 @@
+import { step } from "mocha-steps";
+import * as assert from "assert";
+import { GetAddressUnspentOutputsResponse, GetBlockchainInfoResponse, SlpAction, SlpTransactionInfo } from "grpc-bchrpc-node";
+import { PrivateKey, Networks, Transaction, Script, Address } from "bitcore-lib-cash";
+import * as bchaddrjs from "bchaddrjs-slp";
+import { createGrpcClient, createRpcClient } from "../lib/utils";
+
+import { Bfp, utxo } from "../../lib/bfp";
+import fs from "fs";
+
+// setup RPC clients (used primarily for generating blocks only)
+const bchd1Grpc = createGrpcClient();
+const bchd2Rpc = createRpcClient();
+
+const bfp = new Bfp(bchd1Grpc);
+
+// private key for the mining address (address is stored in bchd.conf)
+//
+// NOTE: bchd doesn't have generatetoaddress, only generate is available.
+//
+const privKey1 = new PrivateKey("cPgxbS8PaxXoU9qCn1AKqQzYwbRCpizbsG98xU2vZQzyZCJt4NjB", Networks.testnet);
+const wallet1 = {
+  _privKey: privKey1,
+  address: privKey1.toAddress().toString(),
+  bchRegtestAddress: bchaddrjs.toRegtestAddress(privKey1.toAddress().toString()),
+  wif: privKey1.toWIF(),
+  pubKey: privKey1.toPublicKey()
+};
+
+// private key for creating transactions (a small amount separate from the mining rewards)
+const privKey2 = new PrivateKey(undefined);
+const wallet2 = {
+  _privKey: privKey2,
+  address: privKey2.toAddress().toString(),
+  bchRegtestAddress: bchaddrjs.toRegtestAddress(privKey2.toAddress().toString()),
+  wif: privKey2.toWIF(),
+  pubKey: privKey2.toPublicKey()
+};
+
+describe("Bitcoin File type 0x02", () => {
+  step("bchd1 ready", async (): Promise<void> => {
+    const info1 = await bchd1Grpc.getBlockchainInfo();
+    assert.strictEqual(info1.getBitcoinNet(), GetBlockchainInfoResponse.BitcoinNet.REGTEST);
+    // console.log(`bchd1 on block ${info1.getBestHeight()}`);
+
+    const res = await bchd2Rpc.getPeerInfo();
+    assert.strictEqual(typeof res, "object");
+    assert.ok(res.length === 1);
+
+    const info2 = await bchd2Rpc.getBlockchainInfo();
+    // console.log(`bchd2 on block ${info2.blocks}`);
+
+    assert.strictEqual(info1.getBestHeight(), info2.blocks);
+  });
+
+  let resBal: GetAddressUnspentOutputsResponse;
+  step("generate block to address", async () => {
+
+    // get balance for address
+    resBal = await bchd1Grpc.getAddressUtxos({ address: wallet1.bchRegtestAddress, includeMempool: true });
+    while (resBal.getOutputsList().length < 100) {
+      await bchd2Rpc.generate(1);
+      resBal = await bchd1Grpc.getAddressUtxos({ address: wallet1.bchRegtestAddress, includeMempool: true });
+    }
+    // console.log(`${resBal.getOutputsList().length} outputs (balance: ${resBal.getOutputsList().reduce((p,c,i) => p += c.getValue() / 10**8, 0)} TBCH)`);
+
+    assert.ok(1);
+  });
+
+  // a variable to keep track of the last unspent bch outpoint in wallet2
+  let prevOutBch: { txid: string, vout: number, satoshis: number };
+
+  // send a small amount from mining rewards to wallet2 address
+  step("send to wallet2", async () => {
+
+    // grab the last unspent coin on the mining address (the aged coin)
+    // NOTE: mined outputs require 100 block aging before they can be spent
+    const output = resBal.getOutputsList()[resBal.getOutputsList().length-1]!;
+
+    // using bitcore-lib to build a transaction
+    const txn = new Transaction();
+
+    // spend the mined output
+    txn.addInput(new Transaction.Input.PublicKeyHash({
+      output: new Transaction.Output({
+        script: Script.buildPublicKeyHashOut(new Address(wallet1.address)),
+        satoshis: output.getValue()
+      }),
+      prevTxId: Buffer.from(output.getOutpoint()!.getHash_asU8()).reverse(),
+      outputIndex: output.getOutpoint()!.getIndex(),
+      script: Script.empty()
+    }));
+
+    // send to wallet2 p2pkh (less a small fee)
+    const sendSatoshis = output.getValue() - 200;
+    txn.addOutput(new Transaction.Output({
+      script: new Script(new Address(wallet2.address)),
+      satoshis: sendSatoshis
+    }));
+
+    // sign
+    txn.sign(wallet1._privKey);
+
+    // serialize
+    const txnHex = txn.serialize();
+
+    // broadcast
+    const res = await bchd1Grpc.submitTransaction({ txnHex });
+    assert.ok(res.getHash_asU8().length === 32);
+
+    // store prevOut for use in the next step
+    prevOutBch = {
+      txid: Buffer.from(res.getHash_asU8()).reverse().toString("hex"),
+      vout: 0,
+      satoshis: sendSatoshis
+    };
+
+    // check gRPC server mempool
+    const resTx = await bchd1Grpc.getTransaction({ hash: prevOutBch.txid, reversedHashOrder: true, includeTokenMetadata: true });
+
+    // check token metadata
+    assert.ok(resTx.getTokenMetadata() === undefined);
+    assert.ok(resTx.getTransaction()!.getOutputsList()[0].getSlpToken() === undefined);
+    assert.ok(resTx.getTransaction()!.getOutputsList()[0].getValue() === sendSatoshis);
+
+    // check slp transaction info
+    const info = resTx.getTransaction()!.getSlpTransactionInfo()!;
+    assert.ok(info.getValidityJudgement() === SlpTransactionInfo.ValidityJudgement.UNKNOWN_OR_INVALID);
+    assert.ok(info.getSlpAction() === SlpAction.NON_SLP);
+  });
+
+  let fileID: string;
+
+  step("Upload an 0x02 file", async function() {
+    this.timeout(5000);
+
+    const filePath = "./content/mario.png";
+    const fileBuf = fs.readFileSync(filePath);
+
+    let txo = {
+      txid: prevOutBch.txid,
+      vout: prevOutBch.vout,
+      satoshis: prevOutBch.satoshis,
+      wif: wallet2.wif,
+      address: wallet2.bchRegtestAddress,
+    } as utxo;
+
+    const cb = (inp: string) => { console.log(inp); }
+    fileID = await bfp.uploadFile(txo, wallet2.bchRegtestAddress, wallet2.wif, fileBuf, "mario", "png", undefined, undefined, wallet2.bchRegtestAddress, cb, cb, cb, cb, 0, 1);
+  });
+
+  step("Download an 0x02 file", async function() {
+    this.timeout(5000);
+    let result = await bfp.downloadFile(fileID);
+    assert.strictEqual(result.passesHashCheck, true);
+  });
+});


### PR DESCRIPTION
`calculateFileUploadCostLarge` needs a slightly different set of args than `calculateFileUploadCost` which I think makes it much more convenient to use.

No "config" is needed, we can assume a full metadata OP_RETURN output and this makes file size enough to calculate satoshis needed (Plus, it makes the calculation much simpler without underestimating).